### PR TITLE
fix/add shortage of textEncoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "sumo-javascript-spec",
+  "version": "1.0.0",
+  "description": "",
+  "main": "sumo.js",
+  "dependencies": {
+    "pako": "^1.0.8",
+    "punycode": "^2.1.1",
+    "text-encoding": "^0.7.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/susucoin-project/sumo-javascript-spec.git"
+  },
+  "keywords": [
+    "sumo"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/susucoin-project/sumo-javascript-spec/issues"
+  },
+  "homepage": "https://github.com/susucoin-project/sumo-javascript-spec#readme"
+}

--- a/sumo.js
+++ b/sumo.js
@@ -19,6 +19,9 @@ withGzipCompression = "1";
 
 var pako = require('pako');
 var punycode = require('punycode');
+var textEncoding = require('text-encoding');
+var TextEncoder = textEncoding.TextEncoder;
+var TextDecoder = textEncoding.TextDecoder;
 
 function toPuny (s) {
   output = punycode.encode(s);


### PR DESCRIPTION
```bash
$ node sumo.js

C:\Users\zinntikumugai\Desktop\Projects\SusucoinProject\sumo-javascript-spec\sumo.js:54
var output = new TextEncoder("utf-8").encode(string);                                                                                 
                 ^
ReferenceError: TextEncoder is not defined
at stringToUint8array (C:\Users\zinntikumugai\Desktop\Projects\SusucoinProject\sumo-javascript-spec\sumo.js:54:16)
at noCompress (C:\Users\zinntikumugai\Desktop\Projects\SusucoinProject\sumo-javascript-spec\sumo.js:98:13)
at toSumo (C:\Users\zinntikumugai\Desktop\Projects\SusucoinProject\sumo-javascript-spec\sumo.js:125:19)
at Object. (C:\Users\zinntikumugai\Desktop\Projects\SusucoinProject\sumo-javascript-spec\sumo.js:154:5)
at Module._compile (internal/modules/cjs/loader.js:689:30)
at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
at Module.load (internal/modules/cjs/loader.js:599:32)
at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
at Function.Module._load (internal/modules/cjs/loader.js:530:3)
at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
```

Fixed the above error
Also added `package.json`